### PR TITLE
Fixed default values and alpha builder

### DIFF
--- a/library/src/main/java/com/balysv/materialripple/MaterialRippleLayout.java
+++ b/library/src/main/java/com/balysv/materialripple/MaterialRippleLayout.java
@@ -596,9 +596,9 @@ public class MaterialRippleLayout extends FrameLayout {
         enableClipPathSupportIfNecessary();
     }
 
-    public void setDefaultRippleAlpha(int alpha) {
-        this.rippleAlpha = alpha;
-        paint.setAlpha(alpha);
+    public void setDefaultRippleAlpha(float alpha) {
+        this.rippleAlpha = (int) (255 * alpha);
+        paint.setAlpha(rippleAlpha);
         invalidate();
     }
 
@@ -737,7 +737,7 @@ public class MaterialRippleLayout extends FrameLayout {
         }
 
         public RippleBuilder rippleAlpha(float alpha) {
-            this.rippleAlpha = 255 * alpha;
+            this.rippleAlpha = alpha;
             return this;
         }
 
@@ -774,7 +774,7 @@ public class MaterialRippleLayout extends FrameLayout {
         public MaterialRippleLayout create() {
             MaterialRippleLayout layout = new MaterialRippleLayout(context);
             layout.setRippleColor(rippleColor);
-            layout.setDefaultRippleAlpha((int) rippleAlpha);
+            layout.setDefaultRippleAlpha(rippleAlpha);
             layout.setRippleDelayClick(rippleDelayClick);
             layout.setRippleDiameter((int) dpToPx(context.getResources(), rippleDiameter));
             layout.setRippleDuration(rippleDuration);


### PR DESCRIPTION
Fixed setting default values when initializing _RippleLayout_ without specifying alpha value. It was rounded to _zero_ by casting to _int_.
Fixed setting alpha value as float. It was multiplied by 255 accidentally.