### PR TITLE
fixed #55: Child view's onClickListener within MaterialRippleLayout doesn't work

### DIFF
--- a/library/src/main/java/com/balysv/materialripple/MaterialRippleLayout.java
+++ b/library/src/main/java/com/balysv/materialripple/MaterialRippleLayout.java
@@ -639,7 +639,11 @@ public class MaterialRippleLayout extends FrameLayout {
 
             // if parent is an AdapterView, try to call its ItemClickListener
             if (getParent() instanceof AdapterView) {
-                clickAdapterView((AdapterView) getParent());
+                // childView performClick at first
+                if ( !childView.performClick() )
+                    // if childView not handle it
+                    // dispatch to adapterView
+                    clickAdapterView((AdapterView) getParent());
             } else if (rippleInAdapter) {
                 // find adapter view
                 clickAdapterView(findParentAdapterView());


### PR DESCRIPTION
childView performClick at first, and if not handled, dispatch to adapterView