### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Including in your project
 -------------------------
 
 ```groovy
-compile 'com.balysv:material-ripple:1.0.2'
+implementation 'com.balysv:material-ripple:1.0.2'
 ```
 
 Check for latest version number on the widget below or visit [Releases](https://github.com/balysv/material-ripple/releases)


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.